### PR TITLE
auto create channels on server join

### DIFF
--- a/create_channels.py
+++ b/create_channels.py
@@ -1,0 +1,56 @@
+import discord
+import data
+
+
+def create_category_if_not_exists(func):
+    async def wrapper(guild: discord.Guild, name: str):
+        category = discord.utils.get(guild.categories, name=name)
+        if not category:
+            await guild.create_category(name)
+        await func(guild, name)
+
+    return wrapper
+
+
+async def create_channels(guild: discord.Guild):
+    await create_category_general(guild, "Ethereal Hyperspace Battleships General")
+
+    for guild_temp in data.guilds:
+        # have put guild_temp.name by guess because guilds are developed in the same time, should be checked
+        await create_category_main_guilds(guild, guild_temp.name)
+
+
+@create_category_if_not_exists
+async def create_category_general(guild: discord.Guild, name: str):
+    general_category = discord.utils.get(guild.categories, name=name)
+    if general_category:
+        if not discord.utils.get(general_category.text_channels, name="general"):
+            await general_category.create_text_channel("general", position=1)
+        # TODO add a announcements channel, store it in the DB to send news
+
+        if not discord.utils.get(general_category.forums, name="questions"):
+            await general_category.create_forum("questions", position=2)
+
+        if not discord.utils.get(general_category.voice_channels, name="general"):
+            await general_category.create_voice_channel("general", position=3)
+
+
+@create_category_if_not_exists
+async def create_category_main_guilds(guild: discord.Guild, name: str):
+    guild_category = discord.utils.get(guild.categories, name=name)
+    if guild_category:
+        if not discord.utils.get(guild_category.text_channels, name="announcements"):
+            await guild_category.create_text_channel("announcements")
+        if not discord.utils.get(guild_category.text_channels, name="general"):
+            await guild_category.create_text_channel("general")
+        if not discord.utils.get(guild_category.text_channels, name="off-topic"):
+            await guild_category.create_text_channel("off-topic")
+
+        if not discord.utils.get(guild_category.forums, name="guides"):
+            await guild_category.create_forum("guides")
+
+        if not discord.utils.get(guild_category.voice_channels, name="quarters"):
+            await guild_category.create_voice_channel("quarters")
+
+        if not discord.utils.get(guild_category.stage_channels, name="meeting room"):
+            await guild_category.create_stage_channel("meeting room")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import discord
 from discord.ext import commands
 
+from create_channels import create_channels
+
 import json
 
 # check discord.py docs AND discord developer portal docs, please use cogs and slash commands (discord.py 2.0)
@@ -72,6 +74,7 @@ async def on_guild_join(guild):
             # TODO should have a complete intro message
             await channel.send("Hello! Welcome to Ethereal Hyperspace Battleships type /help for more info.")
         break
+    await create_channels(guild)
 
 
 # start the bot with the token in the config file


### PR DESCRIPTION
1 general category and 1 category per (main) guild are created with their corresponding channels when the bot joins a server.
Only the main channels have been created, not the feature dependent channels.

DO NOT ACCEPT [until main guilds have been created](https://github.com/IGLADI/IT-project-Ethereal-Hyperspace-Battleships/issues/5) (it uses guild.name) this is temp for review and I used a mock object for testing myself but it will not work without the main guilds merged before.

Fix: [Issue #6 Text/voice discord channels](https://github.com/IGLADI/IT-project-Ethereal-Hyperspace-Battleships/issues/6)